### PR TITLE
Revert "m8d: Fix network search"

### DIFF
--- a/init/init_m8d.cpp
+++ b/init/init_m8d.cpp
@@ -42,7 +42,6 @@ void common_properties()
     property_set("ro.ril.enable.a53", "1");
     property_set("ro.ril.enable.pre_r8fd", "1");
     property_set("ro.ril.enable.r8fd", "1");
-    property_set("ro.ril.telephony.mqanelements", "5");
 }
 
 void dualsim_properties(char const multisim_config[])


### PR DESCRIPTION
* The RIL stack expects a multiple of 4 (default) for the
  RIL_REQUEST_QUERY_AVAILABLE_NETWORKS response
* This hadn't been reverted after switching back to the M8 GPe blobs,
  so do it now (reverts commit f4137b072df09dc4e2c60c6e16c7813e39604a95)

Change-Id: I130b8f5f64646b59e9120acc84eed376c94deb7e